### PR TITLE
Check for ".bcfzip" file extension made case insensitive

### DIFF
--- a/Bcfier/Bcf/BcfContainer.cs
+++ b/Bcfier/Bcf/BcfContainer.cs
@@ -157,7 +157,7 @@ namespace Bcfier.Bcf
       var bcffile = new BcfFile();
       try
       {
-        if (!File.Exists(bcfzipfile) || Path.GetExtension(bcfzipfile)!= ".bcfzip")
+        if (!File.Exists(bcfzipfile) || !String.Equals(Path.GetExtension(bcfzipfile), ".bcfzip", StringComparison.InvariantCultureIgnoreCase))
           return bcffile;
 
 


### PR DESCRIPTION
It won't load our *.BCFZip files otherwise=)
