### PR TITLE
Fix Guid to IfcGuid conversion

### DIFF
--- a/Bcfier/Data/Utils/IfcGuid.cs
+++ b/Bcfier/Data/Utils/IfcGuid.cs
@@ -136,7 +136,7 @@ namespace Bcfier.Data.Utils
       // Creation of six 32 Bit integers from the components of the GUID structure
       num[0] = ( uint ) ( BitConverter.ToUInt32( b, 0 ) / 16777216 );
       num[1] = ( uint ) ( BitConverter.ToUInt32( b, 0 ) % 16777216 );
-      num[2] = ( uint ) ( BitConverter.ToUInt16( b, 4 ) * 256 + BitConverter.ToInt16( b, 6 ) / 256 );
+      num[2] = ( uint ) ( BitConverter.ToUInt16( b, 4 ) * 256 + BitConverter.ToUInt16( b, 6 ) / 256 );
       num[3] = ( uint ) ( ( BitConverter.ToUInt16( b, 6 ) % 256 ) * 65536 + b[8] * 256 + b[9] );
       num[4] = ( uint ) ( b[10] * 65536 + b[11] * 256 + b[12] );
       num[5] = ( uint ) ( b[13] * 65536 + b[14] * 256 + b[15] );


### PR DESCRIPTION
Description: A typo in byte conversion causes the conversion to be incorrect for some Guids

This simple test in my BCFier fork fails:

public void test_guid_to_ifc_guid()
    {
      // given
      Guid guid = Guid.Parse("effe4d36-9c2f-8ed1-7115-53ca7505126c");

      // when
      var ifcGuid = IfcGuid.ToIfcGuid(guid);

      // then
      var expectedIfcGuid = new string("3l$aqsd2_EqN4LKyfr1H9i");
      Assert.That(expectedIfcGuid, Is.EqualTo(ifcGuid));
    }

  Message: 
  String lengths are both 22. Strings differ at index 8.
  Expected: "3l$aqsd2wFqN4LKyfr1H9i"
  But was:  "3l$aqsd2_EqN4LKyfr1H9i"